### PR TITLE
Changed order of fields for german form

### DIFF
--- a/src/postal/forms/de/forms.py
+++ b/src/postal/forms/de/forms.py
@@ -14,3 +14,4 @@ class DEPostalAddressForm(PostalAddressForm):
         self.fields.pop('line2')
         self.fields.pop('state')
         self.fields['country'].initial = "DE"
+        self.fields.keyOrder = ['line1', 'code', 'city', 'country']


### PR DESCRIPTION
I added a line to the german form in order to move the street before zip code, which is default in germany.
