### PR TITLE
resolve pip install django-postal issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
 
     packages = find_packages('src'),
     package_dir = {'': 'src'},
-    package_data={'':['*.txt', '*.js', '*.html', '*.*']},
+    package_data={'':['*.txt', '*.js', '*.html', '*.*', 'templates/postal/*.html']},
 
     install_requires = ['setuptools','django-countries','django-piston'],
 


### PR DESCRIPTION
pip install django-postal and following readme doesn't work, 

because setuptools doesn't copy templates to django-postal packages, 
because templates are not found by find_packages 
because they aren't a python package.

PS: see similar issue in django-forum http://code.google.com/p/django-forum/issues/detail?id=79
PSS: i use debian stable
