### PR TITLE
Italian Postal Address Form, and support for Django 1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ src/*.egg-info
 .settings
 pysqlite2-doc
 distribute*
+.idea
+.Python

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,3 +2,4 @@ Michael Thornhill
 Jannis Leidel
 Tom Drummond
 Noe Nieto
+Francesco Facconi

--- a/src/postal/forms/it/__init__.py
+++ b/src/postal/forms/it/__init__.py
@@ -1,0 +1,1 @@
+__author__ = "Francesco Facconi <francesco@immediatic.it>"

--- a/src/postal/forms/it/forms.py
+++ b/src/postal/forms/it/forms.py
@@ -1,0 +1,18 @@
+""" http://www.bitboost.com/ref/international-address-formats.html """
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+from localflavor.it.forms import ITProvinceSelect, ITZipCodeField
+from postal.forms import PostalAddressForm
+
+
+class ITPostalAddressForm(PostalAddressForm):
+    line1 = forms.CharField(label=_(u"Street"), max_length=50)
+    line2 = forms.CharField(label=_(u"Area"), required=False, max_length=100)
+    city = forms.CharField(label=_(u"City"), max_length=50)
+    state = forms.CharField(label=_(u"Province"), widget=ITProvinceSelect)
+    code = ITZipCodeField(label=_(u"Zip Code"))
+
+    def __init__(self, *args, **kwargs):
+        super(ITPostalAddressForm, self).__init__(*args, **kwargs)
+        self.fields['country'].initial = "IT"
+        self.fields.keyOrder = ['line1', 'line2', 'code', 'city', 'state', 'country']

--- a/src/postal/library.py
+++ b/src/postal/library.py
@@ -7,6 +7,7 @@ from postal.forms.cz.forms import CZPostalAddressForm
 from postal.forms.de.forms import DEPostalAddressForm
 from postal.forms.gb.forms import GBPostalAddressForm
 from postal.forms.ie.forms import IEPostalAddressForm
+from postal.forms.it.forms import ITPostalAddressForm
 from postal.forms.mx.forms import MXPostalAddressForm
 from postal.forms.nl.forms import NLPostalAddressForm
 from postal.forms.pl.forms import PLPostalAddressForm
@@ -20,6 +21,7 @@ country_map = {
     "de": DEPostalAddressForm,
     "gb": GBPostalAddressForm,
     "ie": IEPostalAddressForm,
+    "it": ITPostalAddressForm,
     "mx": MXPostalAddressForm,
     "nl": NLPostalAddressForm,
     "pl": PLPostalAddressForm,

--- a/src/postal/locale/en/LC_MESSAGES/django.po
+++ b/src/postal/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,91 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-02-24 03:20-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: settings.py:7 forms/ar/forms.py:9 forms/co/forms.py:9 forms/cz/forms.py:9
+#: forms/de/forms.py:8 forms/gb/forms.py:9 forms/ie/forms.py:9
+#: forms/it/forms.py:9 forms/mx/forms.py:9 forms/nl/forms.py:8
+#: forms/pl/forms.py:8 forms/ru/forms.py:8 forms/us/forms.py:9
+msgid "Street"
+msgstr "Street"
+
+#: settings.py:8 forms/gb/forms.py:10 forms/ie/forms.py:10
+#: forms/it/forms.py:10 forms/nl/forms.py:9 forms/ru/forms.py:9
+#: forms/us/forms.py:10
+msgid "Area"
+msgstr "Area"
+
+#: settings.py:9 forms/ar/forms.py:11 forms/cz/forms.py:10 forms/de/forms.py:9
+#: forms/it/forms.py:11 forms/mx/forms.py:11 forms/pl/forms.py:9
+#: forms/ru/forms.py:10 forms/us/forms.py:11
+msgid "City"
+msgstr "City"
+
+#: settings.py:10 forms/mx/forms.py:12
+msgid "State"
+msgstr "State"
+
+#: settings.py:11 forms/pl/forms.py:10
+msgid "Zip code"
+msgstr "Zip code"
+
+#: forms/__init__.py:17
+msgid "Country"
+msgstr "Country"
+
+#: forms/ar/forms.py:10 forms/co/forms.py:10 forms/mx/forms.py:10
+msgid "Number"
+msgstr "Number"
+
+#: forms/ar/forms.py:12 forms/it/forms.py:12
+msgid "Province"
+msgstr "Province"
+
+#: forms/ar/forms.py:13 forms/cz/forms.py:11 forms/de/forms.py:10
+#: forms/it/forms.py:13 forms/mx/forms.py:13 forms/nl/forms.py:11
+#: forms/us/forms.py:13
+msgid "Zip Code"
+msgstr "Zip Code"
+
+#: forms/co/forms.py:11
+msgid "Department"
+msgstr "Department"
+
+#: forms/gb/forms.py:11
+msgid "Town"
+msgstr "Town"
+
+#: forms/gb/forms.py:12 forms/ie/forms.py:12 forms/ru/forms.py:11
+msgid "County"
+msgstr "County"
+
+#: forms/gb/forms.py:13
+msgid "Postcode"
+msgstr "Postcode"
+
+#: forms/ie/forms.py:11 forms/nl/forms.py:10
+msgid "Town/City"
+msgstr "Town/City"
+
+#: forms/ru/forms.py:12
+msgid "Postal code"
+msgstr "Postal code"
+
+#: forms/us/forms.py:12
+msgid "US State"
+msgstr "US State"

--- a/src/postal/locale/it/LC_MESSAGES/django.po
+++ b/src/postal/locale/it/LC_MESSAGES/django.po
@@ -1,0 +1,91 @@
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Francesco Facconi <francesco@immediatic.it>, 2015.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-02-24 03:20-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Francesco Facconi <francesco@immediatic.it>\n"
+"Language-Team: it <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: settings.py:7 forms/ar/forms.py:9 forms/co/forms.py:9 forms/cz/forms.py:9
+#: forms/de/forms.py:8 forms/gb/forms.py:9 forms/ie/forms.py:9
+#: forms/it/forms.py:9 forms/mx/forms.py:9 forms/nl/forms.py:8
+#: forms/pl/forms.py:8 forms/ru/forms.py:8 forms/us/forms.py:9
+msgid "Street"
+msgstr "Indirizzo"
+
+#: settings.py:8 forms/gb/forms.py:10 forms/ie/forms.py:10
+#: forms/it/forms.py:10 forms/nl/forms.py:9 forms/ru/forms.py:9
+#: forms/us/forms.py:10
+msgid "Area"
+msgstr "Area"
+
+#: settings.py:9 forms/ar/forms.py:11 forms/cz/forms.py:10 forms/de/forms.py:9
+#: forms/it/forms.py:11 forms/mx/forms.py:11 forms/pl/forms.py:9
+#: forms/ru/forms.py:10 forms/us/forms.py:11
+msgid "City"
+msgstr "Città"
+
+#: settings.py:10 forms/mx/forms.py:12
+msgid "State"
+msgstr "Stato"
+
+#: settings.py:11 forms/pl/forms.py:10
+msgid "Zip code"
+msgstr "CAP"
+
+#: forms/__init__.py:17
+msgid "Country"
+msgstr "Nazione"
+
+#: forms/ar/forms.py:10 forms/co/forms.py:10 forms/mx/forms.py:10
+msgid "Number"
+msgstr "Numero"
+
+#: forms/ar/forms.py:12 forms/it/forms.py:12
+msgid "Province"
+msgstr "Provincia"
+
+#: forms/ar/forms.py:13 forms/cz/forms.py:11 forms/de/forms.py:10
+#: forms/it/forms.py:13 forms/mx/forms.py:13 forms/nl/forms.py:11
+#: forms/us/forms.py:13
+msgid "Zip Code"
+msgstr "CAP"
+
+#: forms/co/forms.py:11
+msgid "Department"
+msgstr "Dipartimento"
+
+#: forms/gb/forms.py:11
+msgid "Town"
+msgstr "Paese"
+
+#: forms/gb/forms.py:12 forms/ie/forms.py:12 forms/ru/forms.py:11
+msgid "County"
+msgstr "Contea"
+
+#: forms/gb/forms.py:13
+msgid "Postcode"
+msgstr "Codice Postale"
+
+#: forms/ie/forms.py:11 forms/nl/forms.py:10
+msgid "Town/City"
+msgstr "Paese/Città"
+
+#: forms/ru/forms.py:12
+msgid "Postal code"
+msgstr "Codice Postale"
+
+#: forms/us/forms.py:12
+msgid "US State"
+msgstr "Stato USA"

--- a/src/postal/tests/test_l10n.py
+++ b/src/postal/tests/test_l10n.py
@@ -36,7 +36,7 @@ class PostalTests(TestCase):
 
     def test_get_de_address(self):
         """
-        Tests that we get the correct widget for Germny
+        Tests that we get the correct widget for Germany
         """
         german_form_class = form_factory("de")
         self.assertNotEqual(german_form_class, None)
@@ -47,6 +47,28 @@ class PostalTests(TestCase):
 
         self.assertEqual(form.fields['line1'].label.lower(), "street")
         self.assertEqual(form.fields.has_key('line2'), False)
+        self.assertEqual(form.fields['city'].label.lower(), "city")
+        self.assertEqual(form.fields['code'].label.lower(), "zip code")
+
+    def test_get_it_address(self):
+        """
+        Tests that we get the correct widget for Italy
+        """
+        italian_form_class = form_factory("it")
+        self.assertNotEqual(italian_form_class, None)
+
+        # only use required fields
+        test_data = {
+            'street': 'Piazza Duomo',
+            'code': '20100',
+            'city': 'Milano',
+            'state': 'MI'
+        }
+        form = italian_form_class(data=test_data)
+
+        self.assertEqual(form.fields['line1'].label.lower(), "street")
+        self.assertEqual(form.fields['line2'].label.lower(), "area")
+        self.assertEqual(form.fields['state'].label.lower(), "province")
         self.assertEqual(form.fields['city'].label.lower(), "city")
         self.assertEqual(form.fields['code'].label.lower(), "zip code")
 

--- a/src/postal/views.py
+++ b/src/postal/views.py
@@ -1,9 +1,12 @@
 from django.http import HttpResponse
 from django.template import RequestContext
 from django.template.loader import render_to_string
-from django.utils import simplejson
-
+try:
+    from django.utils import simplejson
+except ImportError:
+    import json as simplejson
 from postal.library import form_factory
+
 
 def address_inline(request, prefix="", country_code=None, template_name="postal/form.html"):
     """ Displays postal address with localized fields """


### PR DESCRIPTION
I have:
* added the Italian Postal Address Form
* added the locale folder and created localization files for en (English) and it (Italian)
* imported json as simplejson if the import simplejson statement fails, to support Django 1.7 and the deprecation of simplejson
* fixed a typo: Germny is Germany
Hope this helps.